### PR TITLE
WIP - Remove CNAME resolution from APIGW

### DIFF
--- a/src/main/20-public-dns.tf
+++ b/src/main/20-public-dns.tf
@@ -29,6 +29,8 @@ resource "aws_api_gateway_domain_name" "main" {
   endpoint_configuration {
     types = ["REGIONAL"]
   }
+
+  security_policy = "TLS_1_2"
 }
 
 resource "aws_route53_record" "main" {

--- a/src/main/20-public-dns.tf
+++ b/src/main/20-public-dns.tf
@@ -38,7 +38,7 @@ resource "aws_route53_record" "main" {
   zone_id = module.dn_zone.route53_zone_zone_id[keys(var.public_dns_zones)[0]]
   name    = aws_api_gateway_domain_name.main[0].domain_name
   type    = "A"
-  ttl     = var.dns_record_ttl
+  # ttl     = var.dns_record_ttl
   alias {
     name                   = aws_api_gateway_domain_name.main[0].regional_domain_name
     zone_id                = aws_api_gateway_domain_name.main[0].regional_zone_id

--- a/src/main/20-public-dns.tf
+++ b/src/main/20-public-dns.tf
@@ -35,7 +35,11 @@ resource "aws_route53_record" "main" {
   count   = var.apigw_custom_domain_create ? 1 : 0
   zone_id = module.dn_zone.route53_zone_zone_id[keys(var.public_dns_zones)[0]]
   name    = aws_api_gateway_domain_name.main[0].domain_name
-  type    = "CNAME"
-  records = [aws_api_gateway_domain_name.main[0].regional_domain_name]
+  type    = "A"
   ttl     = var.dns_record_ttl
+  alias {
+    name                   = aws_api_gateway_domain_name.main[0].regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.main[0].regional_zone_id
+    evaluate_target_health = true
+  }
 }


### PR DESCRIPTION
This PR should allow service invocation from VPC where a VPC Endpoint for the apigw service is present.
The general idea is that if the calling VPC has a VPC Endpoint for that service and private DNS is enabled, all calls to xyz.execute-api.eu-south-1.amazonaws.com will be resolved with a private IP.

However the tokenizer is not of type "private", see https://github.com/pagopa/tokenizer-data-vault-infra/blob/main/src/main/20-public-dns.tf, thus the idea of explicitly using custom domain names without a CNAME redirection thanks to the Route53 integration.

It should not break anything, however the change has not been tested.